### PR TITLE
Bumped guava version to 26.0-jre

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -34,7 +34,7 @@ project.ext {
  */
 
 dependencies {
-    compile(group: "com.google.guava", name: "guava", version: "16.0.1");
+    compile(group: "com.google.guava", name: "guava", version: "26.0-jre");
     compile(group: "com.github.fge", name: "msg-simple", version: "1.1");
     compile(group: "com.google.code.findbugs", name: "jsr305",
         version: "2.0.1");
@@ -52,8 +52,8 @@ dependencies {
  * External javadoc links
  */
 javadoc.options.links("http://docs.oracle.com/javase/6/docs/api/");
-javadoc.options.links("http://jsr-305.googlecode.com/svn/trunk/javadoc/");
+//javadoc.options.links("http://jsr-305.googlecode.com/svn/trunk/javadoc/");
 javadoc.options.links("http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/");
-javadoc.options.links("http://docs.guava-libraries.googlecode.com/git-history/v16.0.1/javadoc/");
+javadoc.options.links("https://google.github.io/guava/releases/26.0-jre/api/docs/");
 javadoc.options.links("http://fge.github.io/msg-simple/");
 

--- a/src/main/java/com/github/fge/uritemplate/parse/CharMatchers.java
+++ b/src/main/java/com/github/fge/uritemplate/parse/CharMatchers.java
@@ -37,8 +37,8 @@ final class CharMatchers
         .precomputed();
 
     static {
-        final CharMatcher ctl = CharMatcher.JAVA_ISO_CONTROL;
-        final CharMatcher spc = CharMatcher.WHITESPACE;
+        final CharMatcher ctl = CharMatcher.javaIsoControl();
+        final CharMatcher spc = CharMatcher.whitespace();
         /*
          * This doesn't include the %: percent-encoded sequences will be
          * handled in the appropriate template parser


### PR DESCRIPTION
Minor change to handle some api-changes in moving to Guava 26.0-jre,
and removing reference to JSR-305 javadoc (long gone)